### PR TITLE
Bugfix: don't force 1 replica when set to 0

### DIFF
--- a/lib/stats.js
+++ b/lib/stats.js
@@ -92,13 +92,13 @@ function createIndex(index, cb) {
     }
 
     /* defaults */
-    if(!config.refresh_interval) {
+    if(config.refresh_interval == null) {
       config.refresh_interval = 5;
     }
-    if(!config.number_of_shards) {
+    if(config.number_of_shards == null) {
       config.number_of_shards = 2
     }
-    if(!config.number_of_replicas) {
+    if(config.number_of_replicas == null) {
       config.number_of_replicas = 1;
     }
 


### PR DESCRIPTION
`!bla` returns true if `bla` is not set (intended), but also when `bla`
is set to 0 (unintended behaviour). This commit fixes this corner case
by explicitly checking for `null`. This way, if a property is either not
set or set to `null`, the default applies.